### PR TITLE
Add podspec

### DIFF
--- a/react-native-onepassword.podspec
+++ b/react-native-onepassword.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'OnePassword.{h,m}'
   s.platform = :ios, "7.0"
   s.dependency 'React/Core'
+  s.dependency '1PasswordExtension'
 end

--- a/react-native-onepassword.podspec
+++ b/react-native-onepassword.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/batphone/react-native-onepassword", :tag => '1.0.4'}
   s.source_files = 'OnePassword.{h,m}'
   s.platform = :ios, "7.0"
-  s.dependency 'React/Core'
+  s.dependency 'React'
   s.dependency '1PasswordExtension'
 end

--- a/react-native-onepassword.podspec
+++ b/react-native-onepassword.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name = "react-native-onepassword"
+  s.version = "1.0.4"
+  s.summary = "React Native integration with the OnePassword extension."
+  s.license = 'MIT'
+  s.requires_arc = true
+  s.homepage = 'https://github.com/batphone/react-native-onepassword'
+  s.authors = { "jjshammas" => "john@johnshammas.com" }
+  s.source = { :git => "https://github.com/batphone/react-native-onepassword", :tag => '1.0.4'}
+  s.source_files = 'OnePassword.{h,m}'
+  s.platform = :ios, "7.0"
+  s.dependency 'React/Core'
+end

--- a/react-native-onepassword.podspec
+++ b/react-native-onepassword.podspec
@@ -1,14 +1,19 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name = "react-native-onepassword"
-  s.version = "1.0.4"
+  s.version = package["version"]
   s.summary = "React Native integration with the OnePassword extension."
-  s.license = 'MIT'
-  s.requires_arc = true
-  s.homepage = 'https://github.com/batphone/react-native-onepassword'
+  s.homepage = "https://github.com/batphone/react-native-onepassword"
   s.authors = { "jjshammas" => "john@johnshammas.com" }
-  s.source = { :git => "https://github.com/batphone/react-native-onepassword", :tag => '1.0.4'}
-  s.source_files = 'OnePassword.{h,m}'
+  s.license = "MIT"
+  s.source = { :git => "https://github.com/batphone/react-native-onepassword.git", :tag => "#{s.version}"}
+
   s.platform = :ios, "7.0"
-  s.dependency 'React'
-  s.dependency '1PasswordExtension'
+  s.source_files = "OnePassword.{h,m}"
+  
+  s.dependency "React"
+  s.dependency "1PasswordExtension"
 end

--- a/react-native-onepassword.podspec
+++ b/react-native-onepassword.podspec
@@ -6,14 +6,14 @@ Pod::Spec.new do |s|
   s.name = "react-native-onepassword"
   s.version = package["version"]
   s.summary = "React Native integration with the OnePassword extension."
-  s.homepage = "https://github.com/batphone/react-native-onepassword"
+  s.homepage = "https://github.com/DriveWealth/react-native-onepassword"
   s.authors = { "jjshammas" => "john@johnshammas.com" }
   s.license = "MIT"
-  s.source = { :git => "https://github.com/batphone/react-native-onepassword.git", :tag => "#{s.version}"}
+  s.source = { :git => "https://github.com/DriveWealth/react-native-onepassword.git", :tag => "#{s.version}"}
 
   s.platform = :ios, "7.0"
   s.source_files = "OnePassword.{h,m}"
-  
+
   s.dependency "React"
   s.dependency "1PasswordExtension"
 end


### PR DESCRIPTION
Adds file `react-native-onepassword.podspec` to provide the option to link this native code through Cocoa Pods instead of manual linking.  It also specifies 1PasswordExtension as a dependency, so users requiring this module in their Podfile will get the extension automatically.