### PR TITLE
Added android file to allow running on android

### DIFF
--- a/OnePassword.android.js
+++ b/OnePassword.android.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var React = require("react-native");
+
+var OnePassword = {
+  isSupported() {
+    return Promise.reject("Android not supported");
+  },
+
+  findLogin(url) {
+    return Promise.reject("Android not supported");
+  }
+};
+
+module.exports = OnePassword;


### PR DESCRIPTION
This allows the library to run on `Android`, without actually providing support
Currently it was cause an error as `OnePassword` is undefined on android, this allows the code to run on both platforms, file failing `isSupported` on `Android`