### PR TITLE
iPad support fixes #11

### DIFF
--- a/OnePassword.m
+++ b/OnePassword.m
@@ -2,13 +2,35 @@
 #import "OnePasswordExtension.h"
 
 #import <React/RCTUtils.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+#import <React/RCTUIManager.h>
+
+#import <UIKit/UIKit.h>
+#import "UIView+React.h"
+
+@implementation UIView (Recurrence)
+
+- (NSArray<UIView *> *)recurrenceAllSubviews
+{
+    NSMutableArray <UIView *> *all = @[].mutableCopy;
+    void (^getSubViewsBlock)(UIView *current) = ^(UIView *current){
+
+        for (UIView *sub in current.subviews) {
+
+            if ([sub.nativeID  isEqual: @"OnePassword"]) {
+                [all addObject:sub];
+            }
+
+            [all addObjectsFromArray:[sub recurrenceAllSubviews]];
+        }
+    };
+    getSubViewsBlock(self);
+    return [NSArray arrayWithArray:all];
+}
+@end
+
 
 @implementation OnePassword
-
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
-}
 
 RCT_EXPORT_MODULE();
 
@@ -29,8 +51,20 @@ RCT_EXPORT_METHOD(findLogin: (NSString *)url
     UIViewController *controller = RCTPresentedViewController();
     
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIView *sender = nil;
+
+        // Loop through all subviews to find a view with nativeID "OnePassword"
+        UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+        for(UIView *subview in keyWindow.subviews)
+        {
+            for (UIView *subsubview in [subview recurrenceAllSubviews])
+            {
+                sender = subsubview;
+            }
+        }
+        
         [[OnePasswordExtension sharedExtension] findLoginForURLString:url
-        forViewController:controller sender:nil completion:^(NSDictionary *loginDictionary, NSError *error) {
+        forViewController:controller sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
             if (loginDictionary.count == 0) {
                 callback(@[RCTMakeError(@"Error while getting login credentials.", nil, nil)]);
                 return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onepassword",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "OnePassword.ios.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Support for iPad, add nativeID="OnePassword" to the View/TextInput that will contain the 1Password login. 1Pasword will attach the loginWindow to this view.

It works, and it is stable but there is a lot of room for improvement. If you are a Objective C god, please feel free to refactor.